### PR TITLE
Small improvements

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/src/Plugin.js
+++ b/src/Plugin.js
@@ -1,5 +1,4 @@
 /* eslint-disable class-methods-use-this, no-unused-vars */
-import datalayer from './datalayer';
 import {
   addScript,
   addHTML,
@@ -21,6 +20,15 @@ export default class Plugin {
     this.id = id;
     this.config = config;
     this._rulesCallback = _rulesCallback;
+    this.datalayer = { log: () => {} };
+  }
+
+  /**
+   * Internal function to introduce the datalayer to the plugin.
+   * @param {Datalayer} Instance of datalayer.js
+   */
+  setDataLayer(layer) {
+    this.datalayer = layer;
   }
 
   /**
@@ -57,7 +65,7 @@ export default class Plugin {
    * @param  {...any} args send any given args to current log output
    */
   log(...args) {
-    datalayer.log(`[${this.id}]`, ...args);
+    this.datalayer.log(`[${this.id}]`, ...args);
   }
 
   addScript(src, async, onLoad) {

--- a/src/Plugin.spec.js
+++ b/src/Plugin.spec.js
@@ -49,4 +49,14 @@ describe('Plugin', () => {
 
     expect(expectedRulesCb).toHaveBeenCalledWith('my-event', expectedData);
   });
+
+  it('should use mocked logger of datalayer stub', () => {
+    const loggerMock = jest.fn();
+    const plugin = new Plugin('foo');
+
+    plugin.setDataLayer({ log: loggerMock });
+    plugin.log('Test');
+
+    expect(loggerMock).toHaveBeenCalledWith(`[${plugin.getID()}]`, 'Test');
+  });
 });

--- a/src/datalayer.js
+++ b/src/datalayer.js
@@ -154,6 +154,8 @@ export class Datalayer {
       this.log('addPlugin: beforeAddPlugin returned false, skipping plugin', plugin);
       return;
     }
+    // Lets introduce the datalayer instance to the plugin.
+    plugin.setDataLayer(this);
     // add plugin , then broadcast all events that happened since initialization
     // @FIXME: add timestamp to events so plugins can decide to ignore old events
     this.plugins.push(plugin);

--- a/src/datalayer.spec.js
+++ b/src/datalayer.spec.js
@@ -198,6 +198,13 @@ describe('datalayer', () => {
       expect(extensionStub2.beforeAddPlugin).toHaveBeenCalledWith(plugin);
       expect(d7r.plugins).not.toContain(plugin);
     });
+
+    it('should register datalayer to the individual plugin', () => {
+      const d7r = new Datalayer();
+      const plugin = new MockPlugin();
+      d7r.addPlugin(plugin);
+      expect(plugin.datalayer).toBe(d7r);
+    });
   });
 
   describe('broadcast', () => {

--- a/src/lib/queue.js
+++ b/src/lib/queue.js
@@ -38,7 +38,12 @@ export default class EventQueue {
     if (typeof callback === 'function' && callback(subscriber) === false) {
       return;
     }
-    subscriber.handleEvent(name, data);
+    // We should catch potential errors globally
+    try {
+      subscriber.handleEvent(name, data);
+    } catch (e) {
+      throw new Error(`[${subscriber.getID()}] - could not handle event - ${name} : ${e.stack}`);
+    }
   }
 
   /**

--- a/src/lib/queue.spec.js
+++ b/src/lib/queue.spec.js
@@ -90,5 +90,19 @@ describe('EventQueue', () => {
 
       expect(subscriber.caughtEvents.length).toEqual(0);
     });
+
+    it('should thow error if something gets wrong in broadcast', () => {
+      const queue = new EventQueue();
+      const subscriber = new EventSubscriber();
+      const testObject = {};
+
+      subscriber.handleEvent = () => testObject.IamNot.Here;
+
+      queue.subscribe(subscriber);
+
+      expect(() => {
+        queue.broadcastEvent('test', { foo: 123 });
+      }).toThrow();
+    });
   });
 });


### PR DESCRIPTION
1) Introducing datalayer instance to plugin instance.
Since we want to use the global logger (which gets initialised through the datalayer) inside a plugin we somehow need to introduce them to each other.
2) Throw meaningful error if some plugin has a problem during broadcast.
3) An .editorconfig is always nice to have :)   