### PR TITLE
Introduction of baseclass for datalayer.js extensions

### DIFF
--- a/src/Extension.js
+++ b/src/Extension.js
@@ -1,0 +1,33 @@
+/* eslint-disable class-methods-use-this, no-unused-vars */
+import PluExtAbstract from './PluExtAbstract';
+/**
+ * Baseclass for datalayer.js extensions.
+ */
+export default class Extension extends PluExtAbstract {
+  /**
+   * Create a new Extension instance. Child classes have to explicitly set the id
+   * and pass through any additional arguments to the superconstructor.
+   * @param {String} id unique identifier
+   * @param {Object} datalayer.js instance
+   */
+  constructor(id, datalayer) {
+    super(id);
+    this.datalayer = datalayer;
+  }
+
+  /**
+   * Before initialize hook - gets called before datalayer gets initialized.
+   */
+  beforeInitialize() {}
+
+  /**
+   * After initialize hook - gets called after datalayer has been initialized.
+   */
+  afterInitialize() {}
+
+  /**
+   * before parse DOM node hook - can be called through datalayer instance.
+   * @param element
+   */
+  beforeParseDOMNode(element) {}
+}

--- a/src/Extension.spec.js
+++ b/src/Extension.spec.js
@@ -1,0 +1,20 @@
+/* eslint-disable max-len */
+import Extension from './Extension';
+
+describe('Extension', () => {
+  it('should create a new Extension instance with the expected id', () => {
+    const expectedId = 'foo-123';
+
+    const plugin = new Extension(expectedId);
+
+    expect(plugin.id).toEqual(expectedId);
+  });
+
+  it('should return its ID when getID is called', () => {
+    const expectedId = 'foo-123';
+
+    const plugin = new Extension(expectedId);
+
+    expect(plugin.getID()).toEqual(expectedId);
+  });
+});

--- a/src/PluExtAbstract.js
+++ b/src/PluExtAbstract.js
@@ -1,0 +1,23 @@
+/* eslint-disable class-methods-use-this, no-unused-vars */
+/**
+ * Internal abstract baseclass for plugin and extension.
+ */
+export default class PluExtAbstract {
+  /**
+   * Child classes have to explicitly set the id:
+   * @param {String} id unique identifier
+   */
+  constructor(id) {
+    this.id = id;
+  }
+
+  /**
+   * Return the plugin's / extension's unique ID as defined within class constructor. It is worth to mention that
+   * this ID is the same for all instances of this plugin. Instance-specific IDs have to be handled
+   * by the plugin implementation itself.
+   * @returns {String}  unique ID for this plugin
+   */
+  getID() {
+    return this.id;
+  }
+}

--- a/src/PluExtAbstract.spec.js
+++ b/src/PluExtAbstract.spec.js
@@ -1,0 +1,20 @@
+/* eslint-disable max-len */
+import PluExtAbstract from './PluExtAbstract';
+
+describe('PluExtAbstract', () => {
+  it('should create a new PluExtAbstract instance with the expected id', () => {
+    const expectedId = 'foo-123';
+
+    const plugin = new PluExtAbstract(expectedId);
+
+    expect(plugin.id).toEqual(expectedId);
+  });
+
+  it('should return its ID when getID is called', () => {
+    const expectedId = 'foo-123';
+
+    const plugin = new PluExtAbstract(expectedId);
+
+    expect(plugin.getID()).toEqual(expectedId);
+  });
+});

--- a/src/Plugin.js
+++ b/src/Plugin.js
@@ -5,10 +5,12 @@ import {
   addImage,
 } from './helpers';
 
+import PluExtAbstract from './PluExtAbstract';
+
 /**
  * Baseclass for datalayer.js plugins.
  */
-export default class Plugin {
+export default class Plugin extends PluExtAbstract {
   /**
    * Create a new Plugin instance. Child classes have to explicitly set the id
    * and pass through any additional arguments to the superconstructor.
@@ -17,7 +19,7 @@ export default class Plugin {
    * @param {?Function} rules optional rules callback, see documentation for more info
    */
   constructor(id, config = {}, _rulesCallback = null) {
-    this.id = id;
+    super(id);
     this.config = config;
     this._rulesCallback = _rulesCallback;
     this.datalayer = { log: () => {} };
@@ -29,16 +31,6 @@ export default class Plugin {
    */
   setDataLayer(layer) {
     this.datalayer = layer;
-  }
-
-  /**
-   * Return this plugin's unique ID as defined within class constructor. It is worth to mention that
-   * this ID is the same for all instances of this plugin. Instance-specific IDs have to be handled
-   * by the plugin implementation itself.
-   * @returns {String}  unique ID for this plugin
-   */
-  getID() {
-    return this.id;
   }
 
   /**

--- a/src/datalayer.js
+++ b/src/datalayer.js
@@ -12,7 +12,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-import { extend } from './lib/utils';
+import { extend, getPluExtAbstractElementByID } from './lib/utils';
 import EventQueue from './lib/queue';
 
 /**
@@ -107,14 +107,16 @@ export class Datalayer {
    */
   getPluginByID(pluginID) {
     if (this.initialized) {
-      for (let i = 0; i < this.plugins.length; i += 1) {
-        if (this.plugins[i].getID() === pluginID) {
-          return this.plugins[i];
-        }
-      }
-      return null;
+      return getPluExtAbstractElementByID(this.plugins, pluginID);
     }
     throw new Error('.getPluginByID called before .initialize (always wrap in whenReady())');
+  }
+
+  getExtensionByID(extensionID) {
+    if (this.initialized) {
+      return getPluExtAbstractElementByID(this.extensions, extensionID);
+    }
+    throw new Error('.getExtensionByID called before .initialize (always wrap in whenReady())');
   }
 
   /**

--- a/src/datalayer.spec.js
+++ b/src/datalayer.spec.js
@@ -1,6 +1,7 @@
 /* eslint-disable max-len, no-new */
 import Plugin from './Plugin';
 import datalayer, { Datalayer } from './datalayer';
+import Extension from './Extension';
 
 /**
  * Mock plugin to test plugin specific stuff (event retrieval,
@@ -301,9 +302,9 @@ describe('datalayer', () => {
   describe('extensions', () => {
     // dummy extension for testing
     let dummyExtensionInstance = null;
-    const dummyExtension = config => class DummyExtension {
+    const dummyExtension = config => class DummyExtension extends Extension {
       constructor(d7r) {
-        this.datalayer = d7r;
+        super('DummyExtension', d7r);
         this.config = config;
         dummyExtensionInstance = this;
       }
@@ -321,7 +322,10 @@ describe('datalayer', () => {
 
         d7r.use(dummyExtension({ test: '123' }));
 
+        d7r.initialize();
+
         expect(d7r.extensions.length === 1).toBe(true);
+        expect(d7r.getExtensionByID('DummyExtension')).toBeInstanceOf(Extension);
       });
 
       it('should pass the configuration to the extension', () => {

--- a/src/extensions/annotations/annotations.js
+++ b/src/extensions/annotations/annotations.js
@@ -1,5 +1,5 @@
 import 'intersection-observer';
-
+import Extension from '../../Extension';
 /**
  * Offical datalayer.js core extension that works on any given call to
  * datalayer.beforeParseDOMNode and parses the provided node for existing
@@ -20,9 +20,9 @@ import 'intersection-observer';
 export default (config = {
   attributePrefix: 'd7r', // prefix used in attribute names (e.g. `data-d7r-event-*`)
   enableViewEvents: false, // set to `true` to enable view event tracking
-}) => class Annotations {
+}) => class Annotations extends Extension {
   constructor(datalayer) {
-    this.datalayer = datalayer;
+    super('Annotations', datalayer);
     // init observer for element visibility tracking
     if (config.enableViewEvents) {
       this.observer = new window.IntersectionObserver(

--- a/src/extensions/attribution/attribution.js
+++ b/src/extensions/attribution/attribution.js
@@ -14,6 +14,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 import 'marketing.js';
+import Extension from '../../Extension';
 
 export default (config = {
   /**
@@ -21,9 +22,9 @@ export default (config = {
    * @type {AttributionEngine | null}
    */
   engine: null,
-}) => class Attribution {
+}) => class Attribution extends Extension {
   constructor(datalayer) {
-    this.datalayer = datalayer;
+    super('Attribution', datalayer);
   }
 
   /* eslint-disable class-methods-use-this */

--- a/src/extensions/logger/logger.js
+++ b/src/extensions/logger/logger.js
@@ -8,10 +8,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 import SimpleLogger from './SimpleLogger';
+import Extension from '../../Extension';
 
-export default (config = {}) => class Logger {
+export default (config = {}) => class Logger extends Extension {
   constructor(datalayer) {
-    this.datalayer = datalayer;
+    super('Logger', datalayer);
     datalayer.logger = config.logger || new SimpleLogger('[d7r]');
   }
 };

--- a/src/extensions/metadata/metadata.js
+++ b/src/extensions/metadata/metadata.js
@@ -9,7 +9,10 @@
  */
 import { collectMetadata } from '../../lib/utils';
 
-export default (config = { metaPrefix: 'd7r:' }) => class Metadata {
+export default (config = {
+  metaPrefix: 'd7r:',
+  attributePrefix: 'd7r',
+}) => class Metadata {
   constructor(datalayer) {
     this.datalayer = datalayer;
     this.globalData = {};
@@ -27,8 +30,8 @@ export default (config = { metaPrefix: 'd7r:' }) => class Metadata {
         console.error(err);
         return;
       }
-      if (!_element.hasAttribute('data-d7r-handled-event')) {
-        _element.setAttribute('data-d7r-handled-event', 1);
+      if (!_element.hasAttribute(`data-${config.attributePrefix}-handled-event`)) {
+        _element.setAttribute(`data-${config.attributePrefix}-handled-event`, 1);
         this.datalayer.broadcast(obj.name, obj.data);
       }
     }, element);

--- a/src/extensions/metadata/metadata.js
+++ b/src/extensions/metadata/metadata.js
@@ -8,13 +8,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 import { collectMetadata } from '../../lib/utils';
+import Extension from '../../Extension';
 
 export default (config = {
   metaPrefix: 'd7r:',
   attributePrefix: 'd7r',
-}) => class Metadata {
+}) => class Metadata extends Extension {
   constructor(datalayer) {
-    this.datalayer = datalayer;
+    super('Metadata', datalayer);
     this.globalData = {};
   }
 

--- a/src/extensions/metadata/metadata.spec.js
+++ b/src/extensions/metadata/metadata.spec.js
@@ -38,5 +38,18 @@ describe('metadata', () => {
 
       expect(datalayerMock.broadcast).toHaveBeenCalledWith(eventData.name, eventData.data);
     });
+
+    it('should mark metatag of type "d7r:event" as resolved through attribute "data-d7r-handled-event" after calling "beforeParseDOMNode"', () => {
+      const ExtensionClass = metadata();
+      const eventData = { name: 'my-event', data: { foo: 'bar', numberProp2: 42 } };
+      window.document.querySelector('body').innerHTML = `<meta name="d7r:event" content='${JSON.stringify(eventData)}' />`;
+      const extension = new ExtensionClass(datalayerMock);
+
+      extension.beforeParseDOMNode(window.document);
+
+      const tag = window.document.querySelector('meta[name="d7r:event"]');
+
+      expect(tag.hasAttribute('data-d7r-handled-event')).toBeTruthy();
+    });
   });
 });

--- a/src/extensions/methodQueue/methodQueue.js
+++ b/src/extensions/methodQueue/methodQueue.js
@@ -7,7 +7,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-
+import Extension from '../../Extension';
 /**
  * Create a method queue handler within the provided target object. It can be used to
  * communicate with the provided API without the need to directly access the module.
@@ -43,9 +43,9 @@ export const createMethodQueueHandler = (context, queueName, api = {}) => {
   };
 };
 
-export default (config = { queueName: '_d7rq' }) => class MethodQueue {
+export default (config = { queueName: '_d7rq' }) => class MethodQueue extends Extension {
   constructor(datalayer) {
-    this.datalayer = datalayer;
+    super('MethodQueue', datalayer);
   }
 
   afterInitialize() {

--- a/src/index.js
+++ b/src/index.js
@@ -8,5 +8,6 @@ export default datalayer;
 
 // export helpers
 export { default as Plugin } from './Plugin';
+export { default as Extension } from './Extension';
 export * from './extensions';
 export * from './helpers';

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -101,9 +101,19 @@ export function createMethodQueueHandler(context, queueName, api = {}) {
   };
 }
 
+export function getPluExtAbstractElementByID(listOfElements, id) {
+  for (let i = 0; i < listOfElements.length; i += 1) {
+    if (listOfElements[i].getID() === id) {
+      return listOfElements[i];
+    }
+  }
+  return null;
+}
+
 // public API
 export default {
   extend,
   collectMetadata,
   createMethodQueueHandler,
+  getPluExtAbstractElementByID,
 };


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
As a developer it would be nice to have an equivalent function like 'getPluginByID' to retrieve an registered extension.

**Describe the solution you'd like**
Datalayer should introduce a 'getExtensionByID' function. The extensions should be registered in the same way as the plugins.

 